### PR TITLE
Upgrade GeoRuby to DBF v4

### DIFF
--- a/georuby.gemspec
+++ b/georuby.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec"
   s.add_development_dependency "simplecov"
   # TODO: Update for dbf 4.x
-  s.add_development_dependency 'dbf', '~> 2'
+  s.add_development_dependency 'dbf', '~> 4'
   s.add_development_dependency 'json'
   s.add_development_dependency 'nokogiri'
 

--- a/lib/geo_ruby/shp4r/dbf.rb
+++ b/lib/geo_ruby/shp4r/dbf.rb
@@ -20,7 +20,7 @@ module GeoRuby
         end
       end
 
-      class Field < Column::Base
+      class Field < ColumnType::Base
         def initialize(name, type, length, decimal = 0, version = 1, enc = nil)
           super(name, type, length, decimal, version, enc)
         end

--- a/lib/geo_ruby/shp4r/dbf.rb
+++ b/lib/geo_ruby/shp4r/dbf.rb
@@ -29,9 +29,6 @@ module GeoRuby
       # Main DBF File Reader
       class Reader < Table
         alias_method :fields, :columns
-        def header_length
-          @columns_count
-        end
 
         def self.open(f)
           new(f)

--- a/lib/geo_ruby/shp4r/dbf.rb
+++ b/lib/geo_ruby/shp4r/dbf.rb
@@ -20,9 +20,26 @@ module GeoRuby
         end
       end
 
-      class Field < ColumnType::Base
+      # Allow field (column) creation with defaults for decimal, version, and encoding
+      class Field < Column
+        # TODO: Figure out how to unwind Field creation to be able to provide a DBF::Table
+
+        # Shim class to address backward compatibility issues with DBF >= 2.0.13
+        # 
+        # Previous signature was (name, type, length, decimal, version, encoding)
+        # v2.0.13 and later signature is (table, name, type, length, decimal)
+        # with table expected to provide version and encoding
+        class FauxTable
+          attr_reader :version, :encoding
+
+          def initialize(version, encoding)
+            @version, @encoding = version, encoding
+          end
+        end
+
         def initialize(name, type, length, decimal = 0, version = 1, enc = nil)
-          super(name, type, length, decimal, version, enc)
+          table = FauxTable.new(version, enc)
+          super(table, name, type, length, decimal)
         end
       end
 

--- a/spec/geo_ruby/shp4r/shp_spec.rb
+++ b/spec/geo_ruby/shp4r/shp_spec.rb
@@ -1,5 +1,7 @@
 require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
 
+# TODO: Look at https://github.com/Nazz78/georuby/ ... he seems to have addressed this.
+
 describe GeoRuby::Shp4r do
 
   describe 'Point' do

--- a/spec/geo_ruby/shp4r/shp_spec.rb
+++ b/spec/geo_ruby/shp4r/shp_spec.rb
@@ -203,31 +203,44 @@ describe GeoRuby::Shp4r do
       rm_shp_src_files(shpfile)
     end
 
-    # TODO: Figure out why ArgumentError
-    pending ('resolve why these raise ArgumentError on create') do
-      skip 'test_creation' do 
-        shpfile = GeoRuby::Shp4r::ShpFile.create(File.dirname(__FILE__) + '/../../data/point3.shp', GeoRuby::Shp4r::ShpType::POINT, [GeoRuby::Shp4r::Dbf::Field.new('Hoyoyo', 'C', 10, 0)])
-        shpfile.transaction do |tr|
-          tr.add(GeoRuby::Shp4r::ShpRecord.new(GeoRuby::SimpleFeatures::Point.from_x_y(123, 123.4), 'Hoyoyo' => 'HJHJJ'))
-        end
+    it 'test_creation' do 
+      shpfile = GeoRuby::Shp4r::ShpFile.create(
+        File.dirname(__FILE__) + '/../../data/point3.shp',
+        GeoRuby::Shp4r::ShpType::POINT, 
+        [GeoRuby::Shp4r::Dbf::Field.new('Hoyoyo', 'C', 10, 0)]
+      )
 
-        expect(shpfile.record_count).to eql(1)
-
-        rm_shp_src_files(shpfile)
+      shpfile.transaction do |tr|
+        tr.add(GeoRuby::Shp4r::ShpRecord.new(
+          GeoRuby::SimpleFeatures::Point.from_x_y(123, 123.4),
+          'Hoyoyo' => 'HJHJJ'
+        ))
       end
 
-      skip 'test_creation_multipoint' do # TODO: Figure out why ArgumentError
-        shpfile = GeoRuby::Shp4r::ShpFile.create(File.dirname(__FILE__) + '/../../data/multipoint3.shp', GeoRuby::Shp4r::ShpType::MULTIPOINT, [GeoRuby::Shp4r::Dbf::Field.new('Hoyoyo', 'C', 10), GeoRuby::Shp4r::Dbf::Field.new('Hello', 'N', 10)])
-        shpfile.transaction do |tr|
-          tr.add(GeoRuby::Shp4r::ShpRecord.new(GeoRuby::SimpleFeatures::MultiPoint.from_coordinates([[123, 123.4], [345, 12.2]]), 'Hoyoyo' => 'HJHJJ', 'Hello' => 5))
-        end
+      expect(shpfile.record_count).to eql(1)
 
-        expect(shpfile.record_count).to eql(1)
-
-        rm_shp_src_files(shpfile)
-      end
+      rm_shp_src_files(shpfile)
     end
 
-  end
+    it 'test_creation_multipoint' do
+      shpfile = GeoRuby::Shp4r::ShpFile.create(
+        File.dirname(__FILE__) + '/../../data/multipoint3.shp', 
+        GeoRuby::Shp4r::ShpType::MULTIPOINT, [
+          GeoRuby::Shp4r::Dbf::Field.new('Hoyoyo', 'C', 10), 
+          GeoRuby::Shp4r::Dbf::Field.new('Hello', 'N', 10)
+        ]
+      )
 
+      shpfile.transaction do |tr|
+        tr.add(GeoRuby::Shp4r::ShpRecord.new(
+          GeoRuby::SimpleFeatures::MultiPoint.from_coordinates([[123, 123.4], [345, 12.2]]), 
+          'Hoyoyo' => 'HJHJJ', 'Hello' => 5)
+        )
+      end
+
+      expect(shpfile.record_count).to eql(1)
+
+      rm_shp_src_files(shpfile)
+    end
+  end
 end

--- a/spec/geo_ruby/shp4r/shp_spec.rb
+++ b/spec/geo_ruby/shp4r/shp_spec.rb
@@ -1,28 +1,28 @@
 require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
 
-# TODO: Look at https://github.com/Nazz78/georuby/ ... he seems to have addressed this.
+def shp_from_data_file(filename)
+  GeoRuby::Shp4r::ShpFile.open(File.join(SPEC_DATA_DIR, filename))
+end
 
 describe GeoRuby::Shp4r do
 
   describe 'Point' do
-    before(:each) do
-      @shpfile = GeoRuby::Shp4r::ShpFile.open(File.dirname(__FILE__) + '/../../data/point.shp')
-    end
+    subject(:shpfile) {shp_from_data_file('point')}
 
     it 'should parse ok' do
-      expect(@shpfile.record_count).to eql(2)
-      expect(@shpfile.fields.size).to eq(1)
-      expect(@shpfile.shp_type).to eql(GeoRuby::Shp4r::ShpType::POINT)
+      expect(shpfile.record_count).to eql(2)
+      expect(shpfile.fields.size).to eq(1)
+      expect(shpfile.shp_type).to eql(GeoRuby::Shp4r::ShpType::POINT)
     end
 
     it 'should parse fields' do
-      field = @shpfile.fields.first
+      field = shpfile.fields.first
       expect(field.name).to eql('Hoyoyo')
       expect(field.type).to eql('N')
     end
 
     it 'should parse record 1' do
-      rec = @shpfile[0]
+      rec = shpfile[0]
       expect(rec.geometry).to be_kind_of GeoRuby::SimpleFeatures::Point
       expect(rec.geometry.x).to be_within(0.00001).of(-90.08375)
       expect(rec.geometry.y).to be_within(0.00001).of(34.39996)
@@ -30,7 +30,7 @@ describe GeoRuby::Shp4r do
     end
 
     it 'should parse record 2' do
-      rec = @shpfile[1]
+      rec = shpfile[1]
       expect(rec.geometry).to be_kind_of GeoRuby::SimpleFeatures::Point
       expect(rec.geometry.x).to be_within(0.00001).of(-87.82580)
       expect(rec.geometry.y).to be_within(0.00001).of(33.36416)
@@ -40,18 +40,16 @@ describe GeoRuby::Shp4r do
   end
 
   describe 'Polyline' do
-    before(:each) do
-      @shpfile = GeoRuby::Shp4r::ShpFile.open(File.dirname(__FILE__) + '/../../data/polyline.shp')
-    end
-
+    subject(:shpfile) {shp_from_data_file('polyline')}
+    
     it 'should parse ok' do
-      expect(@shpfile.record_count).to eql(1)
-      expect(@shpfile.fields.size).to eq(1)
-      expect(@shpfile.shp_type).to eql(GeoRuby::Shp4r::ShpType::POLYLINE)
+      expect(shpfile.record_count).to eql(1)
+      expect(shpfile.fields.size).to eq(1)
+      expect(shpfile.shp_type).to eql(GeoRuby::Shp4r::ShpType::POLYLINE)
     end
 
     it 'should parse fields' do
-      field = @shpfile.fields.first
+      field = shpfile.fields.first
       expect(field.name).to eql('Chipoto')
       # GeoRuby::Shp4r::Dbf now uses the decimal to choose between int and float
       # So here is N instead of F
@@ -59,7 +57,7 @@ describe GeoRuby::Shp4r do
     end
 
     it 'should parse record 1' do
-      rec = @shpfile[0]
+      rec = shpfile[0]
       expect(rec.geometry).to be_kind_of GeoRuby::SimpleFeatures::MultiLineString
       expect(rec.geometry.length).to eql(1)
       expect(rec.geometry[0].length).to eql(6)
@@ -69,24 +67,22 @@ describe GeoRuby::Shp4r do
   end
 
   describe 'Polygon' do
-    before(:each) do
-      @shpfile = GeoRuby::Shp4r::ShpFile.open(File.dirname(__FILE__) + '/../../data/polygon.shp')
-    end
+    subject(:shpfile) {shp_from_data_file('polygon')}
 
     it 'should parse ok' do
-      expect(@shpfile.record_count).to eql(1)
-      expect(@shpfile.fields.size).to eq(1)
-      expect(@shpfile.shp_type).to eql(GeoRuby::Shp4r::ShpType::POLYGON)
+      expect(shpfile.record_count).to eql(1)
+      expect(shpfile.fields.size).to eq(1)
+      expect(shpfile.shp_type).to eql(GeoRuby::Shp4r::ShpType::POLYGON)
     end
 
     it 'should parse fields' do
-      field = @shpfile.fields.first
+      field = shpfile.fields.first
       expect(field.name).to eql('Hello')
       expect(field.type).to eql('C')
     end
 
     it 'should parse record 1' do
-      rec = @shpfile[0]
+      rec = shpfile[0]
       expect(rec.geometry).to be_kind_of GeoRuby::SimpleFeatures::MultiPolygon
       expect(rec.geometry.length).to eql(1)
       expect(rec.geometry[0].length).to eql(1)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,8 @@ require 'geo_ruby/kml'
 require 'geo_ruby/georss'
 require 'geo_ruby/geojson'
 
+SPEC_DATA_DIR = File.join(File.dirname(__FILE__), 'data')
+
 module GeorubyMatchers
   class BeGeometric
     def matches?(actual)


### PR DESCRIPTION
It looks like the root cause of the imcompatibility is a signature change in `DBF::Column.new` in infused/dbf@36065c0951f5be703c8ccbdd3049e51cddb72dde 

I'm not super proud of this way of fixing it, but it shims the incompatible signatures for now. Future work can seek to make it work better by unwinding DBF creation from field creation ... or someone smarter than me can help me understand how this is supposed to work as it stands. I'm just learning here. =D

cc @infused @nofxx @nazz78