### PR TITLE
Fix conversion to and output of polar coordinates

### DIFF
--- a/lib/geo_ruby/simple_features/point.rb
+++ b/lib/geo_ruby/simple_features/point.rb
@@ -77,6 +77,9 @@ module GeoRuby
       # Their values by default are set to the WGS84 ellipsoid.
       #
       def ellipsoidal_distance(point, a = 6_378_137.0, b = 6_356_752.3142)
+        # TODO: Look at https://github.com/rbur004/vincenty/blob/master/lib/vincenty.rb
+        #   and https://github.com/skyderby/vincenty_distance/blob/master/lib/vincenty.rb
+        #   as reference, or just choose to depend on one of them?
         f = (a - b) / a
         l = (point.lon - lon) * DEG2RAD
 
@@ -156,9 +159,9 @@ module GeoRuby
       # Bearing from a point to another, in degrees.
       def bearing_to(other)
         return 0 if self == other
-        a, b =  other.x - x, other.y - y
-        res =  Math.acos(b / Math.hypot(a,b)) / Math::PI * 180
-        a < 0 ? 360 - res : res
+        theta = Math.atan2(other.x - x, other.y - y)
+        theta += Math::PI * 2 if theta < 0
+        theta / DEG2RAD
       end
 
       # Bearing from a point to another as symbols. (:n, :s, :sw, :ne...)

--- a/lib/geo_ruby/simple_features/point.rb
+++ b/lib/geo_ruby/simple_features/point.rb
@@ -46,7 +46,7 @@ module GeoRuby
       #
       # Euclidian distance in whatever unit the x and y ordinates are.
       def euclidian_distance(point)
-        Math.sqrt((point.x - x)**2 + (point.y - y)**2)
+        Math.hypot((point.x - x),(point.y - y))
       end
 
       # Spherical distance in meters, using 'Haversine' formula.
@@ -54,6 +54,7 @@ module GeoRuby
       # Assumes x is the lon and y the lat, in degrees.
       # The user has to make sure using this distance makes sense
       # (ie she should be in latlon coordinates)
+      # TODO: Look at https://gist.github.com/timols/5268103 for comparison
       def spherical_distance(point, r = 6_370_997.0)
         dlat = (point.lat - lat) * DEG2RAD / 2
         dlon = (point.lon - lon) * DEG2RAD / 2
@@ -94,9 +95,7 @@ module GeoRuby
           sin_lambda = Math.sin(lambda)
           cos_lambda = Math.cos(lambda)
           sin_sigma = \
-          Math.sqrt((cos_u2 * sin_lambda) * (cos_u2 * sin_lambda) +
-                    (cos_u1 * sin_u2 - sin_u1 * cos_u2 * cos_lambda) *
-                    (cos_u1 * sin_u2 - sin_u1 * cos_u2 * cos_lambda))
+          Math.hypot((cos_u2 * sin_lambda), (cos_u1 * sin_u2 - sin_u1 * cos_u2 * cos_lambda))
 
           return 0 if sin_sigma == 0 # coincident points
 
@@ -151,14 +150,14 @@ module GeoRuby
         end
         # TODO: benchmark if worth creating an instance
         # euclidian_distance(Point.from_x_y(xx, yy))
-        Math.sqrt((@x - xx)**2 + (@y - yy)**2)
+        Math.hypot((@x - xx), (@y - yy))
       end
 
       # Bearing from a point to another, in degrees.
       def bearing_to(other)
         return 0 if self == other
         a, b =  other.x - x, other.y - y
-        res =  Math.acos(b / Math.sqrt(a * a + b * b)) / Math::PI * 180
+        res =  Math.acos(b / Math.hypot(a,b)) / Math::PI * 180
         a < 0 ? 360 - res : res
       end
 

--- a/lib/geo_ruby/simple_features/point.rb
+++ b/lib/geo_ruby/simple_features/point.rb
@@ -5,20 +5,15 @@ module GeoRuby
   module SimpleFeatures
     # Represents a point. It is in 3D if the Z coordinate is not +nil+.
     class Point < Geometry
-      DEG2RAD = 0.0174532925199433
-      HALFPI  = 1.5707963267948966
+      DEG2RAD = Math::PI / 180
 
       attr_accessor :x, :y, :z, :m
-      attr_reader :r, :t # radian and theta
 
       # If you prefer calling the coordinates lat and lon
       # (or lng, for GeoKit compatibility)
       alias_method :lon, :x
       alias_method :lng, :x
       alias_method :lat, :y
-      alias_method :rad, :r
-      alias_method :tet, :t
-      alias_method :tetha, :t
 
       def initialize(srid = DEFAULT_SRID, with_z = false, with_m = false)
         super(srid, with_z, with_m)
@@ -313,29 +308,29 @@ module GeoRuby
       end
       alias_method :as_ll, :as_latlong
 
-      # Polar stuff
-      #
-      # http://www.engineeringtoolbox.com/converting-cartesian-polar-coordinates-d_1347.html
-      # http://rcoordinate.rubyforge.org/svn/point.rb
-      # outputs radian
+      # Convert cartesian (stored) to polar coordinates
+      # http://www.java2s.com/Code/Ruby/Development/ConverttheCartesianpointxytopolarmagnitudeanglecoordinates.htm
+      # https://tutorial.math.lamar.edu/classes/calcii/polarcoordinates.aspx
+      # https://www.mathsisfun.com/polar-cartesian-coordinates.html
+
+      # outputs radius
       def r
-        Math.sqrt(@x**2 + @y**2)
+        Math.hypot(y,x)
       end
+      alias_method :rad, :r
 
       # Outputs theta
       def theta_rad
-        if @x.zero?
-          @y < 0 ? 3 * HALFPI : HALFPI
-        else
-          th = Math.atan(@y / @x)
-          r > 0 ? th + 2 * Math::PI : th
-        end
+        Math.atan2(@y, @x)
       end
 
       # Outputs theta in degrees
       def theta_deg
         theta_rad / DEG2RAD
       end
+      alias_method :t, :theta_deg
+      alias_method :tet, :theta_deg
+      alias_method :tetha, :theta_deg
 
       # Outputs an array containing polar distance and theta
       def as_polar

--- a/spec/geo_ruby/simple_features/point_spec.rb
+++ b/spec/geo_ruby/simple_features/point_spec.rb
@@ -251,10 +251,16 @@ describe GeoRuby::SimpleFeatures::Point do
   end
     
   context '#from_rt' do
+    subject(:point) {GeoRuby::SimpleFeatures::Point.from_r_t(1.4142, 45)}
+
     it 'should instantiate a point from polar coordinates' do
-      point = GeoRuby::SimpleFeatures::Point.from_r_t(1.4142, 45)
       expect(point.y).to be_within(0.1).of(1)
       expect(point.x).to be_within(0.1).of(1)
+    end
+
+    it 'should properly store r and t' do
+      expect(point.r).to eql(1.4142)
+      expect(point.t).to eql(45)
     end
   end
     

--- a/spec/geo_ruby/simple_features/point_spec.rb
+++ b/spec/geo_ruby/simple_features/point_spec.rb
@@ -131,6 +131,21 @@ describe GeoRuby::SimpleFeatures::Point do
       expect(point.z).to eql(0.0)
       expect(point.srid).to eql(123)
     end
+    
+    context 'providing polar coordinates when x = 0' do
+      # When x = 0, theta is 𝛑/2 * (y/abs(y))
+
+      subject(:pos_y) {GeoRuby::SimpleFeatures::Point.from_x_y(0.0, 32.3141)}
+      subject(:neg_y) {GeoRuby::SimpleFeatures::Point.from_x_y(0.0, -32.3141)}
+
+      it 'should return +𝛑/2 when y is positive' do
+        expect(pos_y.theta_rad).to be_within(0.0001).of(Math::PI / 2)
+      end
+
+      it 'should return -𝛑/2 when y is negative' do
+        expect(neg_y.theta_rad).to be_within(0.0001).of(-Math::PI / 2)
+      end
+    end
 
     describe '#human_representation' do
       describe '#as_latlong' do
@@ -250,7 +265,7 @@ describe GeoRuby::SimpleFeatures::Point do
     end
   end
     
-  context '#from_rt' do
+  context 'initialized from polar coordinates' do
     subject(:point) {GeoRuby::SimpleFeatures::Point.from_r_t(1.4142, 45)}
 
     it 'should instantiate a point from polar coordinates' do
@@ -258,9 +273,16 @@ describe GeoRuby::SimpleFeatures::Point do
       expect(point.x).to be_within(0.1).of(1)
     end
 
-    it 'should properly store r and t' do
-      expect(point.r).to eql(1.4142)
-      expect(point.t).to eql(45)
+    it 'should properly calculate radius from cartesian (x,y)' do
+      expect(point.r).to be_within(0.000001).of(1.4142)
+    end
+
+    it 'should properly calculate theta as degrees' do
+      expect(point.theta_deg).to be_within(0.0001).of(45)
+    end
+
+    it 'should properly calculate theta as radians' do
+      expect(point.theta_rad).to be_within(0.0001).of(45 * (Math::PI / 180))
     end
   end
     
@@ -465,31 +487,9 @@ describe GeoRuby::SimpleFeatures::Point do
       expect(point.georss_simple_representation(georss_ns: 'hey')).to eql("<hey:point>32.3141 -11.2431</hey:point>\n")
     end
 
-    it 'should print r (polar coords)' do
-      expect(point.r).to be_within(0.000001).of(34.214154)
-    end
-
-    it 'should print theta as degrees' do
-      expect(point.theta_deg).to be_within(0.0001).of(289.184406352127)
-    end
-
-    it 'should print theta as radians' do
-      expect(point.theta_rad).to be_within(0.0001).of(5.04722003626982)
-    end
-
-    it 'should print theta when x is zero y > 0' do
-      pt = GeoRuby::SimpleFeatures::Point.from_x_y(0.0, 32.3141)
-      expect(pt.theta_rad).to be_within(0.0001).of(1.5707963267948966)
-    end
-
-    it 'should print theta when x is zero y < 0' do
-      pt = GeoRuby::SimpleFeatures::Point.from_x_y(0.0, -32.3141)
-      expect(pt.theta_rad).to be_within(0.0001).of(4.71238898038469)
-    end
-
     it 'should output as polar' do
       expect(point.as_polar).to be_instance_of(Array)
-      expect(point.as_polar.size).to eq(2) # .length.should eql(2)
+      expect(point.as_polar.size).to eq(2)
     end
 
     it 'should print out nicely as json/geojson' do


### PR DESCRIPTION
GeoRuby::SimpleFeatures::Point uses cartesian coordinates internally. When `#from_r_t` is used to instantiate a point from polar coordinates, they are converted to cartesian coordinates. If you immediately call `#r` and `#t` on the new `GR::SF::Point`, the radius is recalculated with reasonable precision, but `#t` would return nil.

This PR fixes this by doing the following:

* **Remove `attr_reader :r, :t`** — this normally sets up `#r` and `#t` to return @r and @t respectively. A later definition of `#r` instead overrode the earlier one and performed the cartesian-to-polar conversion and returned the radius; while `#theta_rad` did the same for the angle (theta), `#t` was not an alias to it, and thus returned `nil` in all cases.
* **Simplified `#r` and `#theta_rad`** — lean into the `Math` libraries for `#hypot` and `#atan2`
* Shift convenience aliases to the correct functions
* Increase precision by calculating `DEG2RAD` constant using `Math::PI`
* Replace `Math.sqrt(a**2,b**2)` patterns with `Math.hypot(a,b)` throughout
* Tidy and sort specs

Addresses #1 

cc @nofxx